### PR TITLE
hwmonitor - Fix 1.46 checksum

### DIFF
--- a/automatic/hwmonitor/hwmonitor.nuspec
+++ b/automatic/hwmonitor/hwmonitor.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>hwmonitor</id>
     <title>HWMonitor</title>
-    <version>1.46.0.20220429</version>
+    <version>1.46.0.20220502</version>
     <authors>CPUID</authors>
     <owners>ionred</owners>
     <summary>HWMonitor is a hardware monitoring program that reads PC systems main health sensors : voltages, temperatures, fans speed.</summary>

--- a/automatic/hwmonitor/tools/chocolateyInstall.ps1
+++ b/automatic/hwmonitor/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   silentArgs    = '/SILENT /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
   validExitCodes= @(0)
   softwareName  = '*hwmonitor*'
-  checksum      = '024420291dddd0ad606d995e42794ee2e4907201ed72c8cd8efb6a7c7b418bf0'
+  checksum      = '151bec617b393c99ddb59b3b7fb4fd150ebdae2222e89f25151252b231795e0a'
   checksumType  = 'sha256'
 };
 Install-ChocolateyPackage @packageArgs;


### PR DESCRIPTION
I tried to upgrade to v1.46.0.20220429 on my work laptop earlier today, and the install failed due to a checksum mismatch. CPUID appears to have silently updated the binary. Updated the expected checksum and bumped with package fix version accordingly.

Install was successfully tested against the Chocolatey Test Environment.