### PR TITLE
hwmonitor - Use HTTPS url

### DIFF
--- a/automatic/hwmonitor/tools/chocolateyInstall.ps1
+++ b/automatic/hwmonitor/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@
 $packageName = 'hwmonitor';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)";
 $installerType = 'EXE';
-$url = 'http://download.cpuid.com/hwmonitor/hwmonitor_1.46.exe';
+$url = 'https://download.cpuid.com/hwmonitor/hwmonitor_1.46.exe';
 
 $packageArgs = @{
   packageName   = $packageName

--- a/automatic/hwmonitor/update.ps1
+++ b/automatic/hwmonitor/update.ps1
@@ -18,7 +18,7 @@ function global:au_GetLatest {
 
     #tidy-5.1.25-win64.zip
     #$re  = "tidy-.+-win(32|64).zip"
-    $url = (($download_page.links | Where-Object href -match "/downloads/.*.exe$" | Select-Object -first 1 -expand href) | ForEach-Object { $_ -replace 'http://www.cpuid.com/downloads', '' -replace '/downloads', '' } | ForEach-Object { "http://download.cpuid.com$_"})
+    $url = (($download_page.links | Where-Object href -match "/downloads/.*.exe$" | Select-Object -first 1 -expand href) | ForEach-Object { $_ -replace 'http://www.cpuid.com/downloads', '' -replace '/downloads', '' } | ForEach-Object { "https://download.cpuid.com$_"})
 
     $version = $url -replace '.exe', '' -split '_' | Select-Object -Last 1
     #$url32 = 'https://github.com' + $url[0]

--- a/automatic/hwmonitor/update.ps1
+++ b/automatic/hwmonitor/update.ps1
@@ -18,7 +18,7 @@ function global:au_GetLatest {
 
     #tidy-5.1.25-win64.zip
     #$re  = "tidy-.+-win(32|64).zip"
-    $url = (($download_page.links | Where-Object href -match $regex | Where-Object href -match "/downloads/.*.exe$" | Select-Object -first 1 -expand href) | ForEach-Object { $_ -replace 'http://www.cpuid.com/downloads', '' -replace '/downloads', '' } | ForEach-Object { "http://download.cpuid.com$_"})
+    $url = (($download_page.links | Where-Object href -match "/downloads/.*.exe$" | Select-Object -first 1 -expand href) | ForEach-Object { $_ -replace 'http://www.cpuid.com/downloads', '' -replace '/downloads', '' } | ForEach-Object { "http://download.cpuid.com$_"})
 
     $version = $url -replace '.exe', '' -split '_' | Select-Object -Last 1
     #$url32 = 'https://github.com' + $url[0]


### PR DESCRIPTION
In testing my changeset for #2, I noticed the package was using a HTTP URL. `Get-ChocolateyWebFile` (as called under the hood by `Install-ChocolateyPackage`) will test a given HTTP URL for SSL/TLS availability, and use the HTTPS scheme instead if available, as demonstrated in the log below:

```
PS C:\Users\Administrator> cinst hwmonitor -s .
Chocolatey v1.1.0
Installing the following packages:
hwmonitor
By installing, you accept licenses for the packages.

hwmonitor v1.46.0.20220502
hwmonitor package files install completed. Performing other installation steps.
WARNING: Url has SSL/TLS available, switching to HTTPS for download
Downloading hwmonitor
  from 'https://download.cpuid.com/hwmonitor/hwmonitor_1.46.exe'

Download of hwmonitor_1.46.exe (1.38 MB) completed.
Hashes match.
Installing hwmonitor...
hwmonitor has been installed.
  hwmonitor can be automatically uninstalled.
 The install of hwmonitor was successful.
  Software installed to 'C:\Program Files\CPUID\HWMonitor\'

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```

Changed the install and update scripts accordingly to optimize this check away, and make the URL as passed to `Install-ChocolateyPackage` consistent with what's used at runtime.

**NOTE:** In `update.ps1`, I also removed a seemingly unnecessary command (`Where-Object href -match $regex`) from the `$url` pipeline. `$regex` was undefined in my environment, so that command effectively behaved as a no-op. Feel free to skip over that commit if it breaks something local that I don't have visibility to.