### PR TITLE
checksum: 1 updated - hwmonitor

### DIFF
--- a/automatic/hwmonitor/tools/chocolateyInstall.ps1
+++ b/automatic/hwmonitor/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   silentArgs    = '/SILENT /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
   validExitCodes= @(0)
   softwareName  = '*hwmonitor*'
-  checksum      = '82234f204cb3135d0aef839b25870d6ed71ebc4d75c2b2031ab727e7e570057f'
+  checksum      = '1705d7f37871f655cf58d4cabd85876400990e9bb4095bf6d9b4bf1bcee7d20f'
   checksumType  = 'sha256'
 }
 


### PR DESCRIPTION
Manual update of the checksum for HWMonitor.

```
    File: hwmonitor_1.50.exe
  CRC-32: f7c7f4e4
   SHA-1: a0f6ed435bf4f58fdb03b4b0282ad52578a03fc4
 SHA-256: 1705d7f37871f655cf58d4cabd85876400990e9bb4095bf6d9b4bf1bcee7d20f
 SHA-512: 9d94feed78d05e1a987dc142642352b8efdfdf566e649c1b8121421a4b5b5a066d542a5f9a8cac469237d94ef1b2348bdb89a92f1e21290d7c25979e9ab1a157
```